### PR TITLE
feat: AGENT_RUNTIME feature flag — Lambda/Fargate/both compute selection (rebased successor)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@ AWS_PROFILE=your-aws-profile-name
 AWS_REGION=ap-northeast-2
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 
+# Agent runtime mode: lambda (default), fargate, or both
+# lambda  — Lambda Container Image only ($0 idle, 1.35s cold start)
+# fargate — ECS Fargate Spot only (~68s cold start)
+# both    — Smart routing: Lambda default, Fargate for long tasks
+AGENT_RUNTIME=lambda
+
 # Fargate task resources (optional, defaults shown)
 # FARGATE_CPU=1024
 # FARGATE_MEMORY=2048

--- a/packages/cdk/__tests__/stacks.e2e.test.ts
+++ b/packages/cdk/__tests__/stacks.e2e.test.ts
@@ -355,7 +355,7 @@ describe("ApiStack with PREWARM_SCHEDULE", () => {
       const network = new NetworkStack(app, "PrewarmNetworkStack");
       const storage = new StorageStack(app, "PrewarmStorageStack");
       const auth = new AuthStack(app, "PrewarmAuthStack");
-      const compute = new ComputeStack(app, "PrewarmComputeStack", {
+      new ComputeStack(app, "PrewarmComputeStack", {
         vpc: network.vpc,
         fargateSecurityGroup: network.fargateSecurityGroup,
         conversationsTable: storage.conversationsTable,

--- a/packages/cdk/__tests__/stacks.e2e.test.ts
+++ b/packages/cdk/__tests__/stacks.e2e.test.ts
@@ -68,8 +68,7 @@ describe("CDK Stacks E2E — synth all stacks", () => {
       pendingMessagesTable: storage.pendingMessagesTable,
       userPool: auth.userPool,
       userPoolClient: auth.userPoolClient,
-      cluster: compute.cluster,
-      taskDefinition: compute.taskDefinition,
+      agentRuntime: "fargate",
     });
 
     // Step 1-8: Web UI
@@ -81,7 +80,9 @@ describe("CDK Stacks E2E — synth all stacks", () => {
     });
 
     // Monitoring Dashboard
-    const monitoring = new MonitoringStack(app, "TestMonitoringStack");
+    const monitoring = new MonitoringStack(app, "TestMonitoringStack", {
+      agentRuntime: "fargate",
+    });
 
     secretsTemplate = Template.fromStack(secrets);
     networkTemplate = Template.fromStack(network);
@@ -417,5 +418,316 @@ describe("ApiStack with AGENT_RUNTIME=lambda", () => {
     expect(template).not.toContain("/serverless-openclaw/compute/task-definition-arn");
     expect(template).not.toContain("/serverless-openclaw/compute/task-role-arn");
     expect(template).not.toContain("/serverless-openclaw/compute/execution-role-arn");
+  });
+});
+
+/**
+ * Preservation Property Tests
+ *
+ * These tests verify that fargate and both modes remain unchanged.
+ * They MUST PASS on unfixed code — passing confirms the baseline behavior to preserve.
+ *
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5
+ */
+describe("Preservation: fargate and both modes unchanged", () => {
+  it("fargate mode: NetworkStack creates VPC, ApiStack has Fargate env vars, MonitoringStack has ECS metrics", () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "PresFargateNetworkStack");
+    const storage = new StorageStack(app, "PresFargateStorageStack");
+    const auth = new AuthStack(app, "PresFargateAuthStack");
+
+    const api = new ApiStack(app, "PresFargateApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "fargate",
+    });
+
+    const monitoring = new MonitoringStack(app, "PresFargateMonitoringStack");
+
+    // NetworkStack creates VPC
+    const networkTemplate = Template.fromStack(network);
+    networkTemplate.resourceCountIs("AWS::EC2::VPC", 1);
+
+    // ApiStack Lambda functions have Fargate env vars
+    const apiTemplate = Template.fromStack(api);
+    const functions = apiTemplate.findResources("AWS::Lambda::Function");
+    const fnEntries = Object.entries(functions);
+    expect(fnEntries.length).toBe(7);
+
+    for (const [fnName, fn] of fnEntries) {
+      const props = (fn as Record<string, unknown>).Properties as Record<string, unknown>;
+      const envBlock = props.Environment as Record<string, unknown>;
+      const vars = envBlock.Variables as Record<string, unknown>;
+      expect(vars, `Lambda ${fnName} should have ECS_CLUSTER_ARN`).toHaveProperty("ECS_CLUSTER_ARN");
+      expect(vars, `Lambda ${fnName} should have SUBNET_IDS`).toHaveProperty("SUBNET_IDS");
+    }
+
+    // MonitoringStack dashboard contains AWS/ECS metrics
+    const monTemplate = Template.fromStack(monitoring);
+    const dashboards = monTemplate.findResources("AWS::CloudWatch::Dashboard");
+    const dashboardJson = JSON.stringify(dashboards);
+    expect(dashboardJson).toContain("AWS/ECS");
+  });
+
+  it("both mode: all stacks present, ApiStack has both ECS_CLUSTER_ARN and LAMBDA_AGENT_FUNCTION_ARN", () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "PresBothNetworkStack");
+    const storage = new StorageStack(app, "PresBothStorageStack");
+    const auth = new AuthStack(app, "PresBothAuthStack");
+
+    new ComputeStack(app, "PresBothComputeStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      dataBucket: storage.dataBucket,
+      ecrRepository: storage.ecrRepository,
+    });
+
+    new LambdaAgentStack(app, "PresBothLambdaAgentStack", {
+      dataBucket: storage.dataBucket,
+      taskStateTable: storage.taskStateTable,
+    });
+
+    const api = new ApiStack(app, "PresBothApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "both",
+    });
+
+    // ApiStack has both Fargate and Lambda env vars
+    const apiTemplate = Template.fromStack(api);
+    const functions = apiTemplate.findResources("AWS::Lambda::Function");
+
+    for (const [fnName, fn] of Object.entries(functions)) {
+      const props = (fn as Record<string, unknown>).Properties as Record<string, unknown>;
+      const envBlock = props.Environment as Record<string, unknown>;
+      const vars = envBlock.Variables as Record<string, unknown>;
+      expect(vars, `Lambda ${fnName} should have ECS_CLUSTER_ARN`).toHaveProperty("ECS_CLUSTER_ARN");
+      expect(vars, `Lambda ${fnName} should have LAMBDA_AGENT_FUNCTION_ARN`).toHaveProperty("LAMBDA_AGENT_FUNCTION_ARN");
+    }
+  });
+
+  it("default mode: no agentRuntime defaults to fargate behavior", () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "PresDefaultNetworkStack");
+    const storage = new StorageStack(app, "PresDefaultStorageStack");
+    const auth = new AuthStack(app, "PresDefaultAuthStack");
+
+    // No agentRuntime prop — should default to fargate
+    const api = new ApiStack(app, "PresDefaultApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+    });
+
+    // NetworkStack creates VPC (always created when no agentRuntime)
+    const networkTemplate = Template.fromStack(network);
+    networkTemplate.resourceCountIs("AWS::EC2::VPC", 1);
+
+    // ApiStack has full Fargate env vars (default behavior)
+    const apiTemplate = Template.fromStack(api);
+    const functions = apiTemplate.findResources("AWS::Lambda::Function");
+    expect(Object.keys(functions).length).toBe(7);
+
+    for (const [fnName, fn] of Object.entries(functions)) {
+      const props = (fn as Record<string, unknown>).Properties as Record<string, unknown>;
+      const envBlock = props.Environment as Record<string, unknown>;
+      const vars = envBlock.Variables as Record<string, unknown>;
+      expect(vars, `Lambda ${fnName} should have ECS_CLUSTER_ARN`).toHaveProperty("ECS_CLUSTER_ARN");
+      expect(vars, `Lambda ${fnName} should have TASK_DEFINITION_ARN`).toHaveProperty("TASK_DEFINITION_ARN");
+      expect(vars, `Lambda ${fnName} should have SUBNET_IDS`).toHaveProperty("SUBNET_IDS");
+      expect(vars, `Lambda ${fnName} should have SECURITY_GROUP_IDS`).toHaveProperty("SECURITY_GROUP_IDS");
+    }
+  });
+
+  it("IAM preservation: fargate mode has ECS RunTask/StopTask/DescribeTasks policies", () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "PresIamNetworkStack");
+    const storage = new StorageStack(app, "PresIamStorageStack");
+    const auth = new AuthStack(app, "PresIamAuthStack");
+
+    const api = new ApiStack(app, "PresIamApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "fargate",
+    });
+
+    const apiTemplate = Template.fromStack(api);
+    const templateJson = JSON.stringify(apiTemplate.toJSON());
+
+    // ECS IAM policies must be present for container functions
+    expect(templateJson).toContain("ecs:RunTask");
+    expect(templateJson).toContain("ecs:StopTask");
+    expect(templateJson).toContain("ecs:DescribeTasks");
+  });
+
+  it("dashboard preservation: fargate MonitoringStack has Cold Start, Pre-Warming, and ECS sections", () => {
+    const app = new cdk.App();
+    const monitoring = new MonitoringStack(app, "PresDashMonitoringStack");
+
+    const monTemplate = Template.fromStack(monitoring);
+    const dashboards = monTemplate.findResources("AWS::CloudWatch::Dashboard");
+    const dashboardJson = JSON.stringify(dashboards);
+
+    // Cold Start Performance section
+    expect(dashboardJson).toContain("Cold Start Performance");
+    // Predictive Pre-Warming section
+    expect(dashboardJson).toContain("Predictive Pre-Warming");
+    // ECS CPU/Memory section
+    expect(dashboardJson).toContain("AWS/ECS");
+    expect(dashboardJson).toContain("CPUUtilization");
+    expect(dashboardJson).toContain("MemoryUtilization");
+  });
+});
+
+/**
+ * Bug Condition Exploration Tests
+ *
+ * These tests encode the EXPECTED behavior after the fix.
+ * On UNFIXED code, they are EXPECTED TO FAIL — failure confirms the bug exists.
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5
+ */
+describe("Bug Condition: AGENT_RUNTIME=lambda Fargate dependencies", () => {
+  it("full app synth with AGENT_RUNTIME=lambda creates no NetworkStack VPC resources", () => {
+    // Simulate the FIXED app.ts behavior — when agentRuntime=lambda, NetworkStack is not created
+    const app = new cdk.App();
+    const agentRuntime = "lambda";
+
+    new SecretsStack(app, "BugCondNetSecretsStack");
+    const storage = new StorageStack(app, "BugCondNetStorageStack");
+    const auth = new AuthStack(app, "BugCondNetAuthStack");
+
+    // After fix: NetworkStack is NOT created when agentRuntime=lambda
+    new ApiStack(app, "BugCondNetApiStack", {
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime,
+    });
+
+    // Assert: no VPC resources should exist anywhere in the app when AGENT_RUNTIME=lambda
+    const allStacks = app.node.children.filter((c): c is cdk.Stack => c instanceof cdk.Stack);
+    let vpcCount = 0;
+    for (const stack of allStacks) {
+      const template = Template.fromStack(stack);
+      const vpcs = template.findResources("AWS::EC2::VPC");
+      vpcCount += Object.keys(vpcs).length;
+    }
+    expect(vpcCount).toBe(0);
+  });
+
+  it("ApiStack with agentRuntime=lambda synthesizes without vpc/fargateSecurityGroup props", { timeout: 30_000 }, () => {
+    const app = new cdk.App();
+    const storage = new StorageStack(app, "BugCondApiStorageStack");
+    const auth = new AuthStack(app, "BugCondApiAuthStack");
+
+    // After fix, vpc and fargateSecurityGroup are optional props.
+    const api = new ApiStack(app, "BugCondApiStack", {
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "lambda",
+    });
+
+    const template = JSON.stringify(Template.fromStack(api).toJSON());
+    // Should not contain any Fargate SSM parameter references
+    expect(template).not.toContain("/serverless-openclaw/compute/cluster-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/task-definition-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/task-role-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/execution-role-arn");
+  });
+
+  it("ApiStack with agentRuntime=lambda has no Fargate env vars on Lambda functions", { timeout: 30_000 }, () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "BugCondEnvNetworkStack");
+    const storage = new StorageStack(app, "BugCondEnvStorageStack");
+    const auth = new AuthStack(app, "BugCondEnvAuthStack");
+
+    const api = new ApiStack(app, "BugCondEnvApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "lambda",
+    });
+
+    const template = Template.fromStack(api);
+    const functions = template.findResources("AWS::Lambda::Function");
+
+    const fargateEnvVars = ["ECS_CLUSTER_ARN", "TASK_DEFINITION_ARN", "SUBNET_IDS", "SECURITY_GROUP_IDS"];
+
+    for (const [fnName, fn] of Object.entries(functions)) {
+      const props = (fn as Record<string, unknown>).Properties as Record<string, unknown>;
+      const envBlock = props.Environment as Record<string, unknown> | undefined;
+      const vars = (envBlock?.Variables ?? {}) as Record<string, unknown>;
+
+      for (const envVar of fargateEnvVars) {
+        expect(vars, `Lambda ${fnName} should not have ${envVar}`).not.toHaveProperty(envVar);
+      }
+    }
+  });
+
+  it("MonitoringStack with agentRuntime=lambda has no Fargate dashboard widgets", () => {
+    const app = new cdk.App();
+
+    // After fix, MonitoringStack accepts { agentRuntime } props.
+    const monitoring = new MonitoringStack(app, "BugCondMonMonitoringStack", {
+      agentRuntime: "lambda",
+    });
+
+    const template = Template.fromStack(monitoring);
+    const dashboards = template.findResources("AWS::CloudWatch::Dashboard");
+    const dashboardJson = JSON.stringify(dashboards);
+
+    // Should not contain ECS namespace metrics
+    expect(dashboardJson).not.toContain("AWS/ECS");
+    // Should not contain prewarm custom metrics
+    expect(dashboardJson).not.toContain("PrewarmTriggered");
+    expect(dashboardJson).not.toContain("PrewarmSkipped");
   });
 });

--- a/packages/cdk/__tests__/stacks.e2e.test.ts
+++ b/packages/cdk/__tests__/stacks.e2e.test.ts
@@ -376,8 +376,7 @@ describe("ApiStack with PREWARM_SCHEDULE", () => {
         pendingMessagesTable: storage.pendingMessagesTable,
         userPool: auth.userPool,
         userPoolClient: auth.userPoolClient,
-        cluster: compute.cluster,
-        taskDefinition: compute.taskDefinition,
+        agentRuntime: "fargate",
       });
 
       const template = Template.fromStack(api);

--- a/packages/cdk/__tests__/stacks.e2e.test.ts
+++ b/packages/cdk/__tests__/stacks.e2e.test.ts
@@ -392,3 +392,31 @@ describe("ApiStack with PREWARM_SCHEDULE", () => {
     }
   });
 });
+
+describe("ApiStack with AGENT_RUNTIME=lambda", () => {
+  it("does not contain Fargate SSM dynamic references", () => {
+    const app = new cdk.App();
+    const network = new NetworkStack(app, "LambdaModeNetworkStack");
+    const storage = new StorageStack(app, "LambdaModeStorageStack");
+    const auth = new AuthStack(app, "LambdaModeAuthStack");
+    const api = new ApiStack(app, "LambdaModeApiStack", {
+      vpc: network.vpc,
+      fargateSecurityGroup: network.fargateSecurityGroup,
+      conversationsTable: storage.conversationsTable,
+      settingsTable: storage.settingsTable,
+      taskStateTable: storage.taskStateTable,
+      connectionsTable: storage.connectionsTable,
+      pendingMessagesTable: storage.pendingMessagesTable,
+      userPool: auth.userPool,
+      userPoolClient: auth.userPoolClient,
+      agentRuntime: "lambda",
+    });
+
+    const template = JSON.stringify(Template.fromStack(api).toJSON());
+    // Fargate SSM params must not appear — they don't exist when ComputeStack is skipped
+    expect(template).not.toContain("/serverless-openclaw/compute/cluster-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/task-definition-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/task-role-arn");
+    expect(template).not.toContain("/serverless-openclaw/compute/execution-role-arn");
+  });
+});

--- a/packages/cdk/bin/app.ts
+++ b/packages/cdk/bin/app.ts
@@ -21,8 +21,11 @@ const deployWeb = process.env.DEPLOY_WEB !== "false"; // default: true (deploy w
 // Secrets (SSM SecureString parameters)
 const secrets = new SecretsStack(app, "SecretsStack");
 
-// Step 1-2: Network & Storage
-const network = new NetworkStack(app, "NetworkStack");
+// Step 1-2: Network & Storage — skip NetworkStack when AGENT_RUNTIME=lambda
+let network: NetworkStack | undefined;
+if (agentRuntime !== "lambda") {
+  network = new NetworkStack(app, "NetworkStack");
+}
 const storage = new StorageStack(app, "StorageStack");
 
 // Step 1-6: Auth
@@ -32,8 +35,8 @@ const auth = new AuthStack(app, "AuthStack");
 let compute: ComputeStack | undefined;
 if (agentRuntime !== "lambda") {
   compute = new ComputeStack(app, "ComputeStack", {
-    vpc: network.vpc,
-    fargateSecurityGroup: network.fargateSecurityGroup,
+    vpc: network!.vpc,
+    fargateSecurityGroup: network!.fargateSecurityGroup,
     conversationsTable: storage.conversationsTable,
     settingsTable: storage.settingsTable,
     taskStateTable: storage.taskStateTable,
@@ -60,8 +63,7 @@ if (agentRuntime !== "fargate") {
 // Step 1-5: API Gateway + Lambda
 // Note: compute resources (TaskDef, Cluster ARNs) read from SSM to avoid cross-stack export issues
 const api = new ApiStack(app, "ApiStack", {
-  vpc: network.vpc,
-  fargateSecurityGroup: network.fargateSecurityGroup,
+  ...(network ? { vpc: network.vpc, fargateSecurityGroup: network.fargateSecurityGroup } : {}),
   conversationsTable: storage.conversationsTable,
   settingsTable: storage.settingsTable,
   taskStateTable: storage.taskStateTable,
@@ -87,6 +89,6 @@ if (deployWeb) {
 }
 
 // Monitoring Dashboard
-new MonitoringStack(app, "MonitoringStack");
+new MonitoringStack(app, "MonitoringStack", { agentRuntime });
 
 app.synth();

--- a/packages/cdk/lib/stacks/api-stack.ts
+++ b/packages/cdk/lib/stacks/api-stack.ts
@@ -51,18 +51,26 @@ export class ApiStack extends cdk.Stack {
     const monorepoRoot = path.join(__dirname, "..", "..", "..", "..");
     const handlersDir = path.join(monorepoRoot, "packages", "gateway", "src", "handlers");
 
-    // Read compute resources from SSM (decoupled from ComputeStack)
-    const taskDefArn = ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.TASK_DEFINITION_ARN);
-    const taskRoleArn = ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.TASK_ROLE_ARN);
-    const executionRoleArn = ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.EXECUTION_ROLE_ARN);
-    const clusterArn = ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.CLUSTER_ARN);
-
     // Common environment variables for Lambda functions
     const subnetIds = props.vpc.publicSubnets.map((s) => s.subnetId).join(",");
     const securityGroupIds = props.fargateSecurityGroup.securityGroupId;
 
-    // Lambda agent ARN from SSM (Phase 2)
     const agentRuntime = props.agentRuntime ?? "fargate";
+    const fargateEnabled = agentRuntime !== "lambda";
+
+    // Read Fargate compute resources from SSM — only when ComputeStack is deployed
+    const taskDefArn = fargateEnabled
+      ? ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.TASK_DEFINITION_ARN)
+      : "";
+    const taskRoleArn = fargateEnabled
+      ? ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.TASK_ROLE_ARN)
+      : "";
+    const executionRoleArn = fargateEnabled
+      ? ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.EXECUTION_ROLE_ARN)
+      : "";
+    const clusterArn = fargateEnabled
+      ? ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.CLUSTER_ARN)
+      : "";
     const lambdaAgentEnabled = agentRuntime === "lambda" || agentRuntime === "both";
     const lambdaAgentFunctionArn = lambdaAgentEnabled
       ? ssm.StringParameter.valueForStringParameter(this, SSM_PARAMS.LAMBDA_AGENT_FUNCTION_ARN)
@@ -225,34 +233,33 @@ export class ApiStack extends cdk.Stack {
       }
     }
 
-    // ECS + EC2 permissions for functions that need container management
-    const containerFunctions = [wsMessageFn, telegramWebhookFn, watchdogFn, prewarmFn];
-    for (const fn of containerFunctions) {
-      fn.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: [
-            "ecs:RunTask",
-            "ecs:StopTask",
-            "ecs:DescribeTasks",
-          ],
-          resources: ["*"],
-        }),
-      );
-      fn.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: ["ec2:DescribeNetworkInterfaces"],
-          resources: ["*"],
-        }),
-      );
-      fn.addToRolePolicy(
-        new iam.PolicyStatement({
-          actions: ["iam:PassRole"],
-          resources: [
-            taskRoleArn,
-            executionRoleArn,
-          ],
-        }),
-      );
+    // ECS + EC2 permissions for functions that need container management (Fargate only)
+    if (fargateEnabled) {
+      const containerFunctions = [wsMessageFn, telegramWebhookFn, watchdogFn, prewarmFn];
+      for (const fn of containerFunctions) {
+        fn.addToRolePolicy(
+          new iam.PolicyStatement({
+            actions: [
+              "ecs:RunTask",
+              "ecs:StopTask",
+              "ecs:DescribeTasks",
+            ],
+            resources: ["*"],
+          }),
+        );
+        fn.addToRolePolicy(
+          new iam.PolicyStatement({
+            actions: ["ec2:DescribeNetworkInterfaces"],
+            resources: ["*"],
+          }),
+        );
+        fn.addToRolePolicy(
+          new iam.PolicyStatement({
+            actions: ["iam:PassRole"],
+            resources: [taskRoleArn, executionRoleArn],
+          }),
+        );
+      }
     }
 
     // Lambda agent invoke permission (Phase 2)
@@ -312,7 +319,8 @@ export class ApiStack extends cdk.Stack {
     }
 
     // Grant execute-api:ManageConnections for WebSocket push
-    for (const fn of containerFunctions) {
+    const wsCallbackFunctions = [wsMessageFn, telegramWebhookFn, watchdogFn, prewarmFn];
+    for (const fn of wsCallbackFunctions) {
       fn.addToRolePolicy(
         new iam.PolicyStatement({
           actions: ["execute-api:ManageConnections"],

--- a/packages/cdk/lib/stacks/api-stack.ts
+++ b/packages/cdk/lib/stacks/api-stack.ts
@@ -27,8 +27,8 @@ import { WATCHDOG_INTERVAL_MINUTES } from "@serverless-openclaw/shared";
 import { SSM_PARAMS, SSM_SECRETS } from "./ssm-params.js";
 
 export interface ApiStackProps extends cdk.StackProps {
-  vpc: ec2.IVpc;
-  fargateSecurityGroup: ec2.ISecurityGroup;
+  vpc?: ec2.IVpc;
+  fargateSecurityGroup?: ec2.ISecurityGroup;
   conversationsTable: dynamodb.ITable;
   settingsTable: dynamodb.ITable;
   taskStateTable: dynamodb.ITable;
@@ -52,11 +52,15 @@ export class ApiStack extends cdk.Stack {
     const handlersDir = path.join(monorepoRoot, "packages", "gateway", "src", "handlers");
 
     // Common environment variables for Lambda functions
-    const subnetIds = props.vpc.publicSubnets.map((s) => s.subnetId).join(",");
-    const securityGroupIds = props.fargateSecurityGroup.securityGroupId;
-
     const agentRuntime = props.agentRuntime ?? "fargate";
     const fargateEnabled = agentRuntime !== "lambda";
+
+    let subnetIds = "";
+    let securityGroupIds = "";
+    if (fargateEnabled && props.vpc && props.fargateSecurityGroup) {
+      subnetIds = props.vpc.publicSubnets.map((s) => s.subnetId).join(",");
+      securityGroupIds = props.fargateSecurityGroup.securityGroupId;
+    }
 
     // Read Fargate compute resources from SSM — only when ComputeStack is deployed
     const taskDefArn = fargateEnabled
@@ -82,10 +86,14 @@ export class ApiStack extends cdk.Stack {
       TASK_STATE_TABLE: props.taskStateTable.tableName,
       CONNECTIONS_TABLE: props.connectionsTable.tableName,
       PENDING_MESSAGES_TABLE: props.pendingMessagesTable.tableName,
-      ECS_CLUSTER_ARN: clusterArn,
-      TASK_DEFINITION_ARN: taskDefArn,
-      SUBNET_IDS: subnetIds,
-      SECURITY_GROUP_IDS: securityGroupIds,
+      ...(fargateEnabled
+        ? {
+            ECS_CLUSTER_ARN: clusterArn,
+            TASK_DEFINITION_ARN: taskDefArn,
+            SUBNET_IDS: subnetIds,
+            SECURITY_GROUP_IDS: securityGroupIds,
+          }
+        : {}),
       AGENT_RUNTIME: agentRuntime,
       LAMBDA_AGENT_FUNCTION_ARN: lambdaAgentFunctionArn,
     };

--- a/packages/cdk/lib/stacks/monitoring-stack.ts
+++ b/packages/cdk/lib/stacks/monitoring-stack.ts
@@ -64,9 +64,15 @@ function sectionHeader(title: string, description: string): cloudwatch.TextWidge
   });
 }
 
+export interface MonitoringStackProps extends cdk.StackProps {
+  agentRuntime?: string;
+}
+
 export class MonitoringStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: MonitoringStackProps) {
     super(scope, id, props);
+
+    const fargateEnabled = (props?.agentRuntime ?? "fargate") !== "lambda";
 
     const dashboard = new cloudwatch.Dashboard(this, "Dashboard", {
       dashboardName: "ServerlessOpenClaw",
@@ -74,52 +80,54 @@ export class MonitoringStack extends cdk.Stack {
     });
 
     // ════════════════════════════════════════════════════════════════
-    //  Section 1: Cold Start Performance
+    //  Section 1: Cold Start Performance (Fargate only)
     // ════════════════════════════════════════════════════════════════
 
-    dashboard.addWidgets(
-      sectionHeader(
-        "Cold Start Performance",
-        "Fargate container startup time. Breakdown by phase: S3 restore → Gateway connection → Client ready.",
-      ),
-    );
+    if (fargateEnabled) {
+      dashboard.addWidgets(
+        sectionHeader(
+          "Cold Start Performance",
+          "Fargate container startup time. Breakdown by phase: S3 restore → Gateway connection → Client ready.",
+        ),
+      );
 
-    dashboard.addWidgets(
-      new cloudwatch.SingleValueWidget({
-        title: "Startup Total (p50)",
-        metrics: channelMetrics("StartupTotal", "p50", cloudwatch.Unit.MILLISECONDS),
-        width: 4,
-        height: 4,
-      }),
-      new cloudwatch.GraphWidget({
-        title: "Startup Total — p50 / p99",
-        left: [
-          ...channelMetrics("StartupTotal", "p50", cloudwatch.Unit.MILLISECONDS),
-          ...channelMetrics("StartupTotal", "p99", cloudwatch.Unit.MILLISECONDS),
-        ],
-        width: 8,
-        height: 4,
-        leftYAxis: { label: "ms" },
-      }),
-      new cloudwatch.GraphWidget({
-        title: "Startup Phase Breakdown (avg)",
-        left: [
-          ...channelMetrics("StartupS3Restore", "Average", cloudwatch.Unit.MILLISECONDS),
-          ...channelMetrics("StartupGatewayWait", "Average", cloudwatch.Unit.MILLISECONDS),
-          ...channelMetrics("StartupClientReady", "Average", cloudwatch.Unit.MILLISECONDS),
-        ],
-        width: 6,
-        height: 4,
-        stacked: true,
-        leftYAxis: { label: "ms" },
-      }),
-      new cloudwatch.SingleValueWidget({
-        title: "First Response (p50)",
-        metrics: channelMetrics("FirstResponseTime", "p50", cloudwatch.Unit.MILLISECONDS),
-        width: 6,
-        height: 4,
-      }),
-    );
+      dashboard.addWidgets(
+        new cloudwatch.SingleValueWidget({
+          title: "Startup Total (p50)",
+          metrics: channelMetrics("StartupTotal", "p50", cloudwatch.Unit.MILLISECONDS),
+          width: 4,
+          height: 4,
+        }),
+        new cloudwatch.GraphWidget({
+          title: "Startup Total — p50 / p99",
+          left: [
+            ...channelMetrics("StartupTotal", "p50", cloudwatch.Unit.MILLISECONDS),
+            ...channelMetrics("StartupTotal", "p99", cloudwatch.Unit.MILLISECONDS),
+          ],
+          width: 8,
+          height: 4,
+          leftYAxis: { label: "ms" },
+        }),
+        new cloudwatch.GraphWidget({
+          title: "Startup Phase Breakdown (avg)",
+          left: [
+            ...channelMetrics("StartupS3Restore", "Average", cloudwatch.Unit.MILLISECONDS),
+            ...channelMetrics("StartupGatewayWait", "Average", cloudwatch.Unit.MILLISECONDS),
+            ...channelMetrics("StartupClientReady", "Average", cloudwatch.Unit.MILLISECONDS),
+          ],
+          width: 6,
+          height: 4,
+          stacked: true,
+          leftYAxis: { label: "ms" },
+        }),
+        new cloudwatch.SingleValueWidget({
+          title: "First Response (p50)",
+          metrics: channelMetrics("FirstResponseTime", "p50", cloudwatch.Unit.MILLISECONDS),
+          width: 6,
+          height: 4,
+        }),
+      );
+    }
 
     // ════════════════════════════════════════════════════════════════
     //  Section 2: Message Processing
@@ -254,67 +262,69 @@ export class MonitoringStack extends cdk.Stack {
     );
 
     // ════════════════════════════════════════════════════════════════
-    //  Section 5: Predictive Pre-Warming
+    //  Section 5: Predictive Pre-Warming (Fargate only)
     // ════════════════════════════════════════════════════════════════
 
-    dashboard.addWidgets(
-      sectionHeader(
-        "Predictive Pre-Warming",
-        "Pre-warm triggers and skips. Triggered = new container started proactively. Skipped = existing container reused.",
-      ),
-    );
+    if (fargateEnabled) {
+      dashboard.addWidgets(
+        sectionHeader(
+          "Predictive Pre-Warming",
+          "Pre-warm triggers and skips. Triggered = new container started proactively. Skipped = existing container reused.",
+        ),
+      );
 
-    dashboard.addWidgets(
-      new cloudwatch.GraphWidget({
-        title: "Prewarm Events",
-        left: [
-          new cloudwatch.Metric({
-            namespace: NAMESPACE,
-            metricName: "PrewarmTriggered",
-            statistic: "Sum",
-            period: cdk.Duration.minutes(5),
-            label: "Triggered",
-          }),
-          new cloudwatch.Metric({
-            namespace: NAMESPACE,
-            metricName: "PrewarmSkipped",
-            statistic: "Sum",
-            period: cdk.Duration.minutes(5),
-            label: "Skipped",
-          }),
-        ],
-        width: 12,
-        height: 4,
-      }),
-      new cloudwatch.SingleValueWidget({
-        title: "Prewarm Triggered (24h)",
-        metrics: [
-          new cloudwatch.Metric({
-            namespace: NAMESPACE,
-            metricName: "PrewarmTriggered",
-            statistic: "Sum",
-            period: cdk.Duration.hours(24),
-            label: "Triggered",
-          }),
-        ],
-        width: 6,
-        height: 4,
-      }),
-      new cloudwatch.SingleValueWidget({
-        title: "Prewarm Skipped (24h)",
-        metrics: [
-          new cloudwatch.Metric({
-            namespace: NAMESPACE,
-            metricName: "PrewarmSkipped",
-            statistic: "Sum",
-            period: cdk.Duration.hours(24),
-            label: "Skipped",
-          }),
-        ],
-        width: 6,
-        height: 4,
-      }),
-    );
+      dashboard.addWidgets(
+        new cloudwatch.GraphWidget({
+          title: "Prewarm Events",
+          left: [
+            new cloudwatch.Metric({
+              namespace: NAMESPACE,
+              metricName: "PrewarmTriggered",
+              statistic: "Sum",
+              period: cdk.Duration.minutes(5),
+              label: "Triggered",
+            }),
+            new cloudwatch.Metric({
+              namespace: NAMESPACE,
+              metricName: "PrewarmSkipped",
+              statistic: "Sum",
+              period: cdk.Duration.minutes(5),
+              label: "Skipped",
+            }),
+          ],
+          width: 12,
+          height: 4,
+        }),
+        new cloudwatch.SingleValueWidget({
+          title: "Prewarm Triggered (24h)",
+          metrics: [
+            new cloudwatch.Metric({
+              namespace: NAMESPACE,
+              metricName: "PrewarmTriggered",
+              statistic: "Sum",
+              period: cdk.Duration.hours(24),
+              label: "Triggered",
+            }),
+          ],
+          width: 6,
+          height: 4,
+        }),
+        new cloudwatch.SingleValueWidget({
+          title: "Prewarm Skipped (24h)",
+          metrics: [
+            new cloudwatch.Metric({
+              namespace: NAMESPACE,
+              metricName: "PrewarmSkipped",
+              statistic: "Sum",
+              period: cdk.Duration.hours(24),
+              label: "Skipped",
+            }),
+          ],
+          width: 6,
+          height: 4,
+        }),
+      );
+    }
 
     // ════════════════════════════════════════════════════════════════
     //  Section 6: Infrastructure — ECS & DynamoDB
@@ -327,31 +337,36 @@ export class MonitoringStack extends cdk.Stack {
       ),
     );
 
+    if (fargateEnabled) {
+      dashboard.addWidgets(
+        new cloudwatch.GraphWidget({
+          title: "Fargate CPU / Memory (%)",
+          left: [
+            new cloudwatch.Metric({
+              namespace: "AWS/ECS",
+              metricName: "CPUUtilization",
+              dimensionsMap: { ClusterName: "serverless-openclaw" },
+              statistic: "Average",
+              period: cdk.Duration.minutes(5),
+              label: "CPU",
+            }),
+            new cloudwatch.Metric({
+              namespace: "AWS/ECS",
+              metricName: "MemoryUtilization",
+              dimensionsMap: { ClusterName: "serverless-openclaw" },
+              statistic: "Average",
+              period: cdk.Duration.minutes(5),
+              label: "Memory",
+            }),
+          ],
+          width: 8,
+          height: 4,
+          leftYAxis: { label: "%", max: 100 },
+        }),
+      );
+    }
+
     dashboard.addWidgets(
-      new cloudwatch.GraphWidget({
-        title: "Fargate CPU / Memory (%)",
-        left: [
-          new cloudwatch.Metric({
-            namespace: "AWS/ECS",
-            metricName: "CPUUtilization",
-            dimensionsMap: { ClusterName: "serverless-openclaw" },
-            statistic: "Average",
-            period: cdk.Duration.minutes(5),
-            label: "CPU",
-          }),
-          new cloudwatch.Metric({
-            namespace: "AWS/ECS",
-            metricName: "MemoryUtilization",
-            dimensionsMap: { ClusterName: "serverless-openclaw" },
-            statistic: "Average",
-            period: cdk.Duration.minutes(5),
-            label: "Memory",
-          }),
-        ],
-        width: 8,
-        height: 4,
-        leftYAxis: { label: "%", max: 100 },
-      }),
       new cloudwatch.GraphWidget({
         title: "DynamoDB Read Capacity",
         left: Object.values(TABLE_NAMES).map(

--- a/packages/gateway/__tests__/handlers/telegram-webhook.test.ts
+++ b/packages/gateway/__tests__/handlers/telegram-webhook.test.ts
@@ -240,6 +240,7 @@ describe("telegram-webhook handler", () => {
       expect.anything(),
       "67890",
       "123456",
+      { agentRuntime: undefined },
     );
     expect(mockSendTelegramMessage).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/gateway/src/handlers/prewarm.ts
+++ b/packages/gateway/src/handlers/prewarm.ts
@@ -34,6 +34,12 @@ async function emitMetric(name: string, dimensions?: Array<{ Name: string; Value
 }
 
 export async function handler(): Promise<void> {
+  const agentRuntime = process.env.AGENT_RUNTIME ?? "fargate";
+  if (agentRuntime === "lambda") {
+    console.log("[prewarm] AGENT_RUNTIME=lambda, skipping Fargate prewarm");
+    return;
+  }
+
   const durationMin = parseInt(process.env.PREWARM_DURATION || "", 10) || DEFAULT_PREWARM_DURATION_MIN;
   const prewarmUntil = Date.now() + durationMin * 60 * 1000;
 

--- a/packages/gateway/src/handlers/telegram-webhook.ts
+++ b/packages/gateway/src/handlers/telegram-webhook.ts
@@ -171,9 +171,16 @@ export async function handler(event: {
       containerName: "openclaw",
       environment: taskEnv,
     },
-    agentRuntime: (process.env.AGENT_RUNTIME as "lambda" | "fargate" | "both") ?? "fargate",
+    agentRuntime,
     invokeLambdaAgent,
     lambdaAgentFunctionArn: process.env.LAMBDA_AGENT_FUNCTION_ARN ?? "",
+    onLambdaResponse: async (payloads) => {
+      for (const payload of payloads ?? []) {
+        if (payload.text && botToken) {
+          await sendTelegramMessage(fetch as never, botToken, connectionId, payload.text);
+        }
+      }
+    },
   });
 
   console.log("[telegram] message routed successfully", { userId });

--- a/packages/gateway/src/handlers/telegram-webhook.ts
+++ b/packages/gateway/src/handlers/telegram-webhook.ts
@@ -44,10 +44,12 @@ export async function handler(event: {
     secretToken.length === expectedToken.length &&
     timingSafeEqual(Buffer.from(secretToken), Buffer.from(expectedToken));
   if (!tokenMatch) {
+    console.warn("[telegram] auth failed: secret token mismatch");
     return { statusCode: 403, body: JSON.stringify({ error: "Forbidden" }) };
   }
 
   if (!event.body) {
+    console.log("[telegram] received empty body, ignoring");
     return { statusCode: 200, body: "OK" };
   }
 
@@ -55,10 +57,12 @@ export async function handler(event: {
   try {
     update = JSON.parse(event.body) as TelegramUpdate;
   } catch {
+    console.error("[telegram] failed to parse request body as JSON");
     return { statusCode: 400, body: JSON.stringify({ error: "Invalid JSON" }) };
   }
 
   if (!update.message?.text) {
+    console.log("[telegram] update has no message text, ignoring");
     return { statusCode: 200, body: "OK" };
   }
 
@@ -69,10 +73,14 @@ export async function handler(event: {
   const botToken = secrets.get(process.env.SSM_TELEGRAM_BOT_TOKEN!) ?? "";
   const text = update.message.text;
 
+  console.log("[telegram] received message", { chatId, telegramId, textLength: text.length });
+
   // Handle /link command
   if (text.startsWith("/link ")) {
     const code = text.slice(6).trim();
+    console.log("[telegram] /link command received", { telegramId });
     if (!/^\d{6}$/.test(code)) {
+      console.warn("[telegram] /link invalid code format", { telegramId });
       if (botToken) {
         await sendTelegramMessage(
           fetch as never,
@@ -83,7 +91,10 @@ export async function handler(event: {
       }
       return { statusCode: 200, body: "OK" };
     }
-    const result = await verifyOtpAndLink(dynamoSend, telegramId, code);
+    const result = await verifyOtpAndLink(dynamoSend, telegramId, code, {
+      agentRuntime: process.env.AGENT_RUNTIME,
+    });
+    console.log("[telegram] /link result", { telegramId, success: !("error" in result) });
     if (botToken) {
       const msg = "error" in result
         ? `❌ ${result.error}`
@@ -95,6 +106,7 @@ export async function handler(event: {
 
   // Handle /unlink command
   if (text === "/unlink") {
+    console.log("[telegram] /unlink command received", { telegramId });
     if (botToken) {
       await sendTelegramMessage(
         fetch as never,
@@ -108,18 +120,23 @@ export async function handler(event: {
 
   // Resolve telegram userId to linked cognito userId if available
   const userId = await resolveUserId(dynamoSend, rawUserId);
+  console.log("[telegram] resolved userId", { rawUserId, userId, linked: userId !== rawUserId });
 
-  // Check task state for cold start reply
-  const taskState = await getTaskState(dynamoSend, userId);
-  const needsColdStart = !taskState || taskState.status === "Starting";
+  // Cold start reply — only relevant for Fargate (Lambda has no persistent task state)
+  const agentRuntime = (process.env.AGENT_RUNTIME as "lambda" | "fargate" | "both") ?? "fargate";
+  if (agentRuntime !== "lambda") {
+    const taskState = await getTaskState(dynamoSend, userId);
+    const needsColdStart = !taskState || taskState.status === "Starting";
+    console.log("[telegram] fargate task state", { userId, taskStatus: taskState?.status ?? "none", needsColdStart });
 
-  if (needsColdStart && botToken) {
-    await sendTelegramMessage(
-      fetch as never,
-      botToken,
-      connectionId,
-      "🔄 Waking up the agent... please wait.",
-    );
+    if (needsColdStart && botToken) {
+      await sendTelegramMessage(
+        fetch as never,
+        botToken,
+        connectionId,
+        "🔄 Waking up the agent... please wait.",
+      );
+    }
   }
 
   // Build environment for RunTask — include TELEGRAM_CHAT_ID when using resolved userId
@@ -132,6 +149,7 @@ export async function handler(event: {
     taskEnv.push({ name: "TELEGRAM_CHAT_ID", value: String(chatId) });
   }
 
+  console.log("[telegram] routing message", { userId, channel: "telegram", agentRuntime });
   await routeMessage({
     userId,
     message: text,
@@ -158,5 +176,6 @@ export async function handler(event: {
     lambdaAgentFunctionArn: process.env.LAMBDA_AGENT_FUNCTION_ARN ?? "",
   });
 
+  console.log("[telegram] message routed successfully", { userId });
   return { statusCode: 200, body: "OK" };
 }

--- a/packages/gateway/src/handlers/watchdog.ts
+++ b/packages/gateway/src/handlers/watchdog.ts
@@ -58,6 +58,12 @@ async function getActiveTimeout(): Promise<number> {
 }
 
 export async function handler(): Promise<void> {
+  const agentRuntime = process.env.AGENT_RUNTIME ?? "fargate";
+  if (agentRuntime === "lambda") {
+    console.log("[watchdog] AGENT_RUNTIME=lambda, skipping Fargate watchdog");
+    return;
+  }
+
   const cluster = process.env.ECS_CLUSTER_ARN ?? "";
   const now = Date.now();
   const timeout = await getActiveTimeout();

--- a/packages/gateway/src/handlers/ws-message.ts
+++ b/packages/gateway/src/handlers/ws-message.ts
@@ -13,6 +13,7 @@ import { getTaskState, putTaskState, deleteTaskState } from "../services/task-st
 import { routeMessage, savePendingMessage } from "../services/message.js";
 import { startTask } from "../services/container.js";
 import { resolveSecrets } from "../services/secrets.js";
+import { invokeLambdaAgent } from "../services/lambda-agent.js";
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const ecs = new ECSClient({});
@@ -96,6 +97,9 @@ export async function handler(event: {
           { name: "CALLBACK_URL", value: process.env.WEBSOCKET_CALLBACK_URL ?? "" },
         ],
       },
+      agentRuntime: (process.env.AGENT_RUNTIME as "lambda" | "fargate" | "both") ?? "fargate",
+      invokeLambdaAgent,
+      lambdaAgentFunctionArn: process.env.LAMBDA_AGENT_FUNCTION_ARN ?? "",
     });
 
     if (result === "started" || result === "queued") {

--- a/packages/gateway/src/handlers/ws-message.ts
+++ b/packages/gateway/src/handlers/ws-message.ts
@@ -72,7 +72,13 @@ export async function handler(event: {
   }
 
   if (msg.action === "sendMessage") {
+    const agentRuntime = (process.env.AGENT_RUNTIME as "lambda" | "fargate" | "both") ?? "fargate";
     const secrets = await resolveSecrets([process.env.SSM_BRIDGE_AUTH_TOKEN!]);
+
+    if (agentRuntime === "lambda" || agentRuntime === "both") {
+      await pushToConnection(connectionId, { type: "status", status: "running" });
+    }
+
     const result = await routeMessage({
       userId,
       message: msg.message ?? "",
@@ -97,9 +103,17 @@ export async function handler(event: {
           { name: "CALLBACK_URL", value: process.env.WEBSOCKET_CALLBACK_URL ?? "" },
         ],
       },
-      agentRuntime: (process.env.AGENT_RUNTIME as "lambda" | "fargate" | "both") ?? "fargate",
+      agentRuntime,
       invokeLambdaAgent,
       lambdaAgentFunctionArn: process.env.LAMBDA_AGENT_FUNCTION_ARN ?? "",
+      onLambdaResponse: async (payloads) => {
+        for (const payload of payloads ?? []) {
+          if (payload.text) {
+            await pushToConnection(connectionId, { type: "message", content: payload.text });
+          }
+        }
+        await pushToConnection(connectionId, { type: "status", status: "Idle" });
+      },
     });
 
     if (result === "started" || result === "queued") {

--- a/packages/gateway/src/services/identity.ts
+++ b/packages/gateway/src/services/identity.ts
@@ -79,6 +79,7 @@ export async function verifyOtpAndLink(
   send: Send,
   telegramUserId: string,
   code: string,
+  options?: { agentRuntime?: string },
 ): Promise<{ cognitoUserId: string } | { error: string }> {
   const telegramKey = `telegram:${telegramUserId}`;
 
@@ -101,22 +102,24 @@ export async function verifyOtpAndLink(
   }
   const cognitoUserId = otpOwner.cognitoUserId;
 
-  // 2. Check if telegram user has a running container (before consuming OTP)
-  const taskResult = (await send(
-    new GetCommand({
-      TableName: TABLE_NAMES.TASK_STATE,
-      Key: { PK: `${KEY_PREFIX.USER}${telegramKey}` },
-    }),
-  )) as GetResult;
+  // 2. Check if telegram user has a running container (Fargate only)
+  if (options?.agentRuntime !== "lambda") {
+    const taskResult = (await send(
+      new GetCommand({
+        TableName: TABLE_NAMES.TASK_STATE,
+        Key: { PK: `${KEY_PREFIX.USER}${telegramKey}` },
+      }),
+    )) as GetResult;
 
-  const taskState = taskResult.Item as
-    | { status: string }
-    | undefined;
-  if (taskState && taskState.status !== "Idle") {
-    return {
-      error:
-        "A Telegram container is currently running. Please try again in about 15 minutes.",
-    };
+    const taskState = taskResult.Item as
+      | { status: string }
+      | undefined;
+    if (taskState && taskState.status !== "Idle") {
+      return {
+        error:
+          "A Telegram container is currently running. Please try again in about 15 minutes.",
+      };
+    }
   }
 
   // 3. Check if telegram is already linked to a different account

--- a/packages/gateway/src/services/message.ts
+++ b/packages/gateway/src/services/message.ts
@@ -72,6 +72,8 @@ export interface RouteDeps {
   invokeLambdaAgent?: (params: InvokeLambdaAgentParams) => Promise<LambdaAgentResponse>;
   lambdaAgentFunctionArn?: string;
   sessionId?: string;
+  /** Called with agent payloads after a successful lambda invocation — caller is responsible for delivery */
+  onLambdaResponse?: (payloads: LambdaAgentResponse["payloads"]) => Promise<void>;
 }
 
 export type RouteResult = "sent" | "queued" | "started" | "lambda";
@@ -171,6 +173,9 @@ export async function routeMessage(deps: RouteDeps): Promise<RouteResult> {
     if (!response.success) {
       throw new Error(response.error ?? "Lambda agent failed");
     }
+    if (deps.onLambdaResponse) {
+      await deps.onLambdaResponse(response.payloads);
+    }
     return "lambda";
   }
 
@@ -204,6 +209,9 @@ export async function routeMessage(deps: RouteDeps): Promise<RouteResult> {
       connectionId: deps.connectionId,
     });
     if (response.success) {
+      if (deps.onLambdaResponse) {
+        await deps.onLambdaResponse(response.payloads);
+      }
       return "lambda";
     }
     // Lambda failed — fall back to Fargate


### PR DESCRIPTION
## Summary

Rebased successor to #19 after #18 landed.

Adds an `AGENT_RUNTIME` environment variable (`fargate` | `lambda` | `both`, default `fargate`) that controls which compute backend handles agent requests:

- `fargate`: existing Fargate path, no behavior change
- `lambda`: skips Fargate infrastructure and Fargate-only checks
- `both`: smart routing with Lambda-by-default, Fargate reuse, `/heavy` and `/fargate` hints, and Lambda-to-Fargate fallback

### Changes

- `ApiStack`: skip Fargate SSM lookups and ECS grants in lambda-only mode
- `telegram-webhook.ts` and `identity.ts`: skip Fargate task-state checks when runtime is `lambda`
- `watchdog.ts` and `prewarm.ts`: early-return when runtime is `lambda`
- `cdk/bin/app.ts`: skip `NetworkStack` creation in lambda-only mode
- `MonitoringStack`: remove Fargate dashboard sections in lambda-only mode
- `.env.example`: document `AGENT_RUNTIME`
- E2E tests: add preservation and bug-condition coverage for all runtime modes

## Validation

- `npm run build`
- `npm run lint`
- `npm run test`
- `npm run test:e2e`

## Notes

- This PR supersedes #19, which was blocked after #18 landed as a squash merge.
